### PR TITLE
Return exit code

### DIFF
--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -30,7 +30,7 @@ final class PublishCommand extends BaseCommand
      * @param Filesystem $filesystem
      * @throws \Sammyjo20\Lasso\Exceptions\ConfigFailedValidation
      */
-    public function handle(Artisan $artisan, Filesystem $filesystem)
+    public function handle(Artisan $artisan, Filesystem $filesystem): int
     {
         (new ConfigValidator())->validate();
 
@@ -54,5 +54,7 @@ final class PublishCommand extends BaseCommand
         $artisan->note(sprintf(
             '✅ Successfully published assets to "%s" filesystem! Yee-haw! 🐎', $filesystem->getCloudDisk()
         ));
+
+        return 0;
     }
 }

--- a/src/Commands/PullCommand.php
+++ b/src/Commands/PullCommand.php
@@ -31,7 +31,7 @@ final class PullCommand extends BaseCommand
      * @param Filesystem $filesystem
      * @throws \Sammyjo20\Lasso\Exceptions\ConfigFailedValidation
      */
-    public function handle(Artisan $artisan, Filesystem $filesystem)
+    public function handle(Artisan $artisan, Filesystem $filesystem): int
     {
         (new ConfigValidator())->validate();
 
@@ -48,5 +48,7 @@ final class PullCommand extends BaseCommand
 
         $artisan->note('✅ Successfully downloaded the latest assets. Yee-haw!');
         $artisan->note('❤️  Thank you for using Lasso. https://getlasso.dev');
+
+        return 0;
     }
 }


### PR DESCRIPTION
It's a best practice to exit commands with a status code.

See also: https://github.com/laravel/framework/blob/43bea00fd27c76c01fd009e46725a54885f4d2a5/src/Illuminate/Foundation/Console/stubs/console.stub#L33-L42