### PR TITLE
Remove version constraint from `composer require` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Lasso is still in early development. Therefore, I haven't yet written any tests 
 Lasso requires Laravel 6+ and PHP 7.3 or higher. To install Lasso, simply run the composer require command below:
 
 ```bash
-composer require sammyjo20/lasso ^1.2
+composer require sammyjo20/lasso
 ```
 
 After that, run the command below to create the lasso.php config file:


### PR DESCRIPTION
No need to add the version constraint here. Composer will always pull in the latest version. Secondly you won't have to update the REAME when you bump your version.