### PR TITLE
Only dispatch Webhooks when there are some available

### DIFF
--- a/src/Tasks/Publish/PublishJob.php
+++ b/src/Tasks/Publish/PublishJob.php
@@ -100,7 +100,6 @@ final class PublishJob extends BaseJob
             // Webhook URLs defined in the "publish" array.
 
             $this->cleanUp();
-
             $webhooks = config('lasso.webhooks.publish', []);
             $this->dispatchWebhooks($webhooks);
         } catch (\Exception $ex) {
@@ -132,7 +131,7 @@ final class PublishJob extends BaseJob
      */
     public function dispatchWebhooks(array $webhooks = []): void
     {
-        if (!count($webhooks)) {
+        if (! count($webhooks)) {
             return;
         }
 

--- a/src/Tasks/Publish/PublishJob.php
+++ b/src/Tasks/Publish/PublishJob.php
@@ -101,12 +101,8 @@ final class PublishJob extends BaseJob
 
             $this->cleanUp();
 
-            $this->artisan->note('✅ Successfully published assets.')
-                ->note('⏳ Dispatching webhooks...');
-
-            $this->dispatchWebhooks();
-
-            $this->artisan->note('✅ Webhooks dispatched.');
+            $webhooks = config('lasso.webhooks.publish', []);
+            $this->dispatchWebhooks($webhooks);
         } catch (\Exception $ex) {
             $this->rollBack($ex);
         }
@@ -132,15 +128,21 @@ final class PublishJob extends BaseJob
     }
 
     /**
-     * @return void
+     * @param array $webhooks
      */
-    public function dispatchWebhooks(): void
+    public function dispatchWebhooks(array $webhooks = []): void
     {
-        $webhooks = config('lasso.webhooks.publish', []);
+        if (!count($webhooks)) {
+            return;
+        }
+
+        $this->artisan->note('⏳ Dispatching webhooks...');
 
         foreach ($webhooks as $webhook) {
             Webhook::send($webhook, 'publish');
         }
+
+        $this->artisan->note('✅ Webhooks dispatched.');
     }
 
     /**

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -105,7 +105,7 @@ final class PullJob extends BaseJob
      */
     public function dispatchWebhooks(array $webhooks = []): void
     {
-        if (!count($webhooks)) {
+        if (! count($webhooks)) {
             return;
         }
 
@@ -144,7 +144,7 @@ final class PullJob extends BaseJob
         // let's just grab that file.If we don't have a file on the server
         // however; we need to throw an exception.
 
-        if (!$this->cloud->exists($cloudPath)) {
+        if (! $this->cloud->exists($cloudPath)) {
             $this->rollBack(
                 PullJobFailed::because('A valid "lasso-bundle.json" file could not be found in the Filesystem for the current environment.')
             );
@@ -165,7 +165,7 @@ final class PullJob extends BaseJob
      */
     private function validateBundle(array $bundle): bool
     {
-        if (!isset($bundle['file']) || !isset($bundle['checksum'])) {
+        if (! isset($bundle['file']) || ! isset($bundle['checksum'])) {
             $this->rollBack(
                 PullJobFailed::because('The bundle info was missing the required data.')
             );
@@ -185,7 +185,7 @@ final class PullJob extends BaseJob
         $bundlePath = $this->cloud->getUploadPath($file);
         $localBundlePath = base_path('.lasso/bundle.zip');
 
-        if (!$this->cloud->exists($bundlePath)) {
+        if (! $this->cloud->exists($bundlePath)) {
             $this->rollBack(
                 PullJobFailed::because('The bundle zip does not exist. If you are using a specific environment, please make sure the LASSO_ENV is the same in your .env file.')
             );
@@ -209,7 +209,7 @@ final class PullJob extends BaseJob
         // If the integrity is incorrect, it could have been downloaded
         // incorrectly or tampered with!
 
-        if (!BundleIntegrityHelper::verifyChecksum($localBundlePath, $checksum)) {
+        if (! BundleIntegrityHelper::verifyChecksum($localBundlePath, $checksum)) {
             $this->rollBack(
                 PullJobFailed::because('The bundle Zip\'s checksum is incorrect.')
             );

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -88,12 +88,8 @@ final class PullJob extends BaseJob
 
         $this->cleanUp();
 
-        $this->artisan->note('✅ Successfully updated assets.')
-            ->note('⏳ Dispatching webhooks...');
-
-        $this->dispatchWebhooks();
-
-        $this->artisan->note('✅ Webhooks dispatched.');
+        $webhooks = config('lasso.webhooks.pull', []);
+        $this->dispatchWebhooks($webhooks);
     }
 
     /**
@@ -105,15 +101,21 @@ final class PullJob extends BaseJob
     }
 
     /**
-     * @return void
+     * @param array $webhooks
      */
-    public function dispatchWebhooks(): void
+    public function dispatchWebhooks(array $webhooks = []): void
     {
-        $webhooks = config('lasso.webhooks.pull', []);
+        if (!count($webhooks)) {
+            return;
+        }
+
+        $this->artisan->note('⏳ Dispatching webhooks...');
 
         foreach ($webhooks as $webhook) {
             Webhook::send($webhook, 'pull');
         }
+
+        $this->artisan->note('✅ Webhooks dispatched.');
     }
 
     /**


### PR DESCRIPTION
- Disabled the "Dispatching Webhooks" message when there aren't any Webhooks listed in the config.webhooks arrays.
- Removed duplicate "success" messages on the Publish and Pull job commands.