### PR TITLE
(task) corrects grammar in comments

### DIFF
--- a/config/lasso.php
+++ b/config/lasso.php
@@ -13,13 +13,13 @@ return [
 
         /*
          * Configure the amount of time (in seconds) the compiler
-         * should run before it times out. By default this is set
+         * should run before it times out. By default, this is set
          * to 600 seconds (10 minutes).
          */
         'timeout' => 600,
 
         /*
-         * If there any directories/files you would like to Lasso to
+         * If there are any directories/files you would like to Lasso to
          * exclude when uploading to the Filesystem, specify them below.
          */
         'excluded_files' => [],
@@ -31,7 +31,7 @@ return [
     'storage' => [
 
         /*
-         * Specify the filesystem Lasso should use to use to store
+         * Specify the filesystem Lasso should use to store
          * and retrieve its files.
          */
         'disk' => 'assets',
@@ -54,7 +54,7 @@ return [
 
         /*
          * Lasso will automatically version the assets. This is useful if you
-         * suddenly need to roll-back a deployment and use an older version
+         * suddenly need to roll back a deployment and use an older version
          * of built files. You can set the maximum amount of files stored here.
          */
         'max_bundles' => 5,

--- a/src/Services/VersioningService.php
+++ b/src/Services/VersioningService.php
@@ -31,7 +31,7 @@ final class VersioningService
 
     /**
      * Get the versioning file from the Filesystem Disk.
-     * This is a file Lasso stores to keep track of it's versions.
+     * This is a file Lasso stores to keep track of its versions.
      *
      * @return array
      * @throws \Sammyjo20\Lasso\Exceptions\BaseException

--- a/src/Tasks/Publish/PublishJob.php
+++ b/src/Tasks/Publish/PublishJob.php
@@ -40,7 +40,7 @@ final class PublishJob extends BaseJob
             $this->artisan->note('⏳ Compiling assets...');
 
             // Start with the compiler. This will run the "script" which
-            // has been defined in the config file (e.g npm run production).
+            // has been defined in the config file (e.g. npm run production).
 
             (new Command())
                 ->setScript(config('lasso.compiler.script'))
@@ -61,9 +61,9 @@ final class PublishJob extends BaseJob
 
             $this->artisan->note('✅ Successfully copied and zipped assets.');
 
-            // Now we want to create the data which will go inside of the
+            // Now we want to create the data which will go inside the
             // "lasso-bundle.json" file. After that, we will create a Zip file
-            // with all of the assets inside.
+            // with all the assets inside.
 
             $bundle = (new Bundle())
                 ->setBundleId($this->bundleId)
@@ -96,7 +96,7 @@ final class PublishJob extends BaseJob
                 $this->cloud->uploadFile($bundlePath, 'lasso-bundle.json');
             }
 
-            // Done! Let's run some cleanup, and dispatch all of the
+            // Done! Let's run some cleanup, and dispatch all the
             // Webhook URLs defined in the "publish" array.
 
             $this->cleanUp();


### PR DESCRIPTION
I noticed a very small double phrase in the config comments when I pushed the config in my project so I ran through to see if I could find other small grammar mistakes.  There weren't many!  Awesome work!