### PR TITLE
Feature: --use-commit flag

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -71,10 +71,12 @@ After running this command, Lasso will create a "lasso-bundle.json" file in your
 
 **Warning: When using the `--no-git` flag, versioning will be limited as the lasso-bundle.json is stored in your Filesystem, rather than your repository. Using Git is the recommended approach.**
 
+If you use git, and want to easily keep track of which bundle file is for what commit, use the `--use-commit` flag. It will ensure the bundle zip file name is the first 12 characters of the commit hash. This also adds the advantage of publishing the bundles during your CI pipeline, without having to make a new commit, whilst giving the versioning benefits of using git.
 ### Pull
 
 The pull command should then be executed on your deployment script, or on the servers which will require the assets to be on. Simply run the command below. If you are using *Laravel Forge*, add this command to your deployment script. If you are using *Laravel Envoyer*, add this to the list of hooks during your deployment. It should be run on **every server**.
 
+Use the `--use-commit` flag when pulling, if you are publishing the bundles with the `--use-commit` flag.
 ```bash
 php artisan lasso:pull
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "gustavtrenwith/lasso",
+    "name": "sammyjo20/lasso",
     "type": "library",
     "description": "Lasso - Asset wrangling for Laravel made simple.",
     "version": "1.2.8",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sammyjo20/lasso",
+    "name": "gustavtrenwith/lasso",
     "type": "library",
     "description": "Lasso - Asset wrangling for Laravel made simple.",
     "version": "1.2.8",

--- a/config/lasso.php
+++ b/config/lasso.php
@@ -92,6 +92,4 @@ return [
      * you have changed this - please specify it below.
      */
     'public_path' => public_path(),
-
-    'git_branch' => env('LASSO_GIT_BRANCH', 'main'),
 ];

--- a/config/lasso.php
+++ b/config/lasso.php
@@ -93,4 +93,5 @@ return [
      */
     'public_path' => public_path(),
 
+    'git_branch' => env('LASSO_GIT_BRANCH', 'main'),
 ];

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -14,14 +14,14 @@ final class PublishCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'lasso:publish {--no-git} {--silent} {--use-commit}';
+    protected $signature = 'lasso:publish {--no-git} {--silent} {--use-commit} {--with-commit=}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Compile assets and push assets to the specified Lasso Filesystem Disk.';
+    protected $description = 'Compile and push assets to the specified Lasso Filesystem Disk.';
 
     /**
      * Execute the console command.
@@ -39,6 +39,7 @@ final class PublishCommand extends BaseCommand
 
         $dontUseGit = $this->option('no-git') === true;
         $useCommit = $this->option('use-commit') === true;
+        $withCommit = $this->option('with-commit');
         $this->configureApplication($artisan, $filesystem);
 
         $job = new PublishJob;
@@ -49,6 +50,10 @@ final class PublishCommand extends BaseCommand
 
         if ($useCommit) {
             $job->useCommit();
+        }
+
+        if ($withCommit) {
+            $job->withCommit($withCommit);
         }
 
         $artisan->note(sprintf(

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -14,7 +14,7 @@ final class PublishCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'lasso:publish {--no-git} {--silent}';
+    protected $signature = 'lasso:publish {--no-git} {--silent} {--use-commit}';
 
     /**
      * The console command description.
@@ -37,12 +37,17 @@ final class PublishCommand extends BaseCommand
         $this->configureApplication($artisan, $filesystem, true);
 
         $dontUseGit = $this->option('no-git') === true;
+        $useCommit = $this->option('use-commit') === true;
         $this->configureApplication($artisan, $filesystem);
 
         $job = new PublishJob;
 
         if ($dontUseGit) {
             $job->dontUseGit();
+        }
+
+        if ($useCommit) {
+            $job->useCommit();
         }
 
         $artisan->note(sprintf(

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -28,6 +28,7 @@ final class PublishCommand extends BaseCommand
      *
      * @param Artisan $artisan
      * @param Filesystem $filesystem
+     * @return int
      * @throws \Sammyjo20\Lasso\Exceptions\ConfigFailedValidation
      */
     public function handle(Artisan $artisan, Filesystem $filesystem): int

--- a/src/Commands/PullCommand.php
+++ b/src/Commands/PullCommand.php
@@ -57,7 +57,7 @@ final class PullCommand extends BaseCommand
         }
 
         if ($withCommit) {
-            $job->withCommit(substr(0, 12, $withCommit));
+            $job->withCommit(substr($withCommit, 0, 12));
         }
 
         $job->run();

--- a/src/Commands/PullCommand.php
+++ b/src/Commands/PullCommand.php
@@ -15,7 +15,7 @@ final class PullCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'lasso:pull {--silent} {--use-commit} {--with-commit?=}';
+    protected $signature = 'lasso:pull {--silent} {--use-commit} {--with-commit=}';
 
     /**
      * The console command description.

--- a/src/Commands/PullCommand.php
+++ b/src/Commands/PullCommand.php
@@ -57,7 +57,7 @@ final class PullCommand extends BaseCommand
         }
 
         if ($withCommit) {
-            $job->withCommit($withCommit);
+            $job->withCommit(substr(0, 12, $withCommit));
         }
 
         $job->run();

--- a/src/Commands/PullCommand.php
+++ b/src/Commands/PullCommand.php
@@ -57,7 +57,7 @@ final class PullCommand extends BaseCommand
         }
 
         if ($withCommit) {
-            $job->setCommit($withCommit);
+            $job->withCommit($withCommit);
         }
 
         $job->run();

--- a/src/Commands/PullCommand.php
+++ b/src/Commands/PullCommand.php
@@ -15,7 +15,7 @@ final class PullCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'lasso:pull {--silent}';
+    protected $signature = 'lasso:pull {--silent} {--use-commit}';
 
     /**
      * The console command description.
@@ -29,12 +29,17 @@ final class PullCommand extends BaseCommand
      *
      * @param Artisan $artisan
      * @param Filesystem $filesystem
+     * @return int
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws \Sammyjo20\Lasso\Exceptions\BaseException
      * @throws \Sammyjo20\Lasso\Exceptions\ConfigFailedValidation
+     * @throws \Sammyjo20\Lasso\Exceptions\PullJobFailed
      */
     public function handle(Artisan $artisan, Filesystem $filesystem): int
     {
         (new ConfigValidator())->validate();
 
+        $useCommit = $this->option('use-commit') === true;
         $this->configureApplication($artisan, $filesystem);
 
         $artisan->setCommand($this);
@@ -44,8 +49,13 @@ final class PullCommand extends BaseCommand
             $filesystem->getCloudDisk()
         ));
 
-        (new PullJob())
-            ->run();
+        $job = new PullJob();
+
+        if ($useCommit) {
+            $job->useCommit();
+        }
+
+        $job->run();
 
         $artisan->note('✅ Successfully downloaded the latest assets. Yee-haw!');
         $artisan->note('❤️  Thank you for using Lasso. https://getlasso.dev');

--- a/src/Commands/PullCommand.php
+++ b/src/Commands/PullCommand.php
@@ -15,7 +15,7 @@ final class PullCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'lasso:pull {--silent} {--use-commit}';
+    protected $signature = 'lasso:pull {--silent} {--use-commit} {--with-commit?=}';
 
     /**
      * The console command description.
@@ -40,6 +40,7 @@ final class PullCommand extends BaseCommand
         (new ConfigValidator())->validate();
 
         $useCommit = $this->option('use-commit') === true;
+        $withCommit = $this->option('with-commit');
         $this->configureApplication($artisan, $filesystem);
 
         $artisan->setCommand($this);
@@ -53,6 +54,10 @@ final class PullCommand extends BaseCommand
 
         if ($useCommit) {
             $job->useCommit();
+        }
+
+        if ($withCommit) {
+            $job->setCommit($withCommit);
         }
 
         $job->run();

--- a/src/Exceptions/GitHashException.php
+++ b/src/Exceptions/GitHashException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sammyjo20\Lasso\Exceptions;
+
+class GitHashException extends BaseException
+{
+    //
+}

--- a/src/Helpers/Git.php
+++ b/src/Helpers/Git.php
@@ -13,7 +13,8 @@ class Git
     public static function getCommitHash():? string
     {
         try {
-            $hash = file_get_contents(base_path() . '/.git/HEAD');
+            $branch = str_replace("\n", '', last(explode('/', file_get_contents(base_path() . '/.git/HEAD'))));
+            $hash = file_get_contents(base_path() . '/.git/refs/heads/' . $branch);
         } catch (\Exception $exception) {
             throw new GitHashException($exception->getMessage(), $exception);
         }

--- a/src/Helpers/Git.php
+++ b/src/Helpers/Git.php
@@ -13,9 +13,7 @@ class Git
     public static function getCommitHash():? string
     {
         try {
-            $hash = file_get_contents(
-                sprintf(base_path() . '/.git/refs/heads/%s', config('lasso.git_branch'))
-            );
+            $hash = file_get_contents(base_path() . '/.git/HEAD');
         } catch (\Exception $exception) {
             throw new GitHashException($exception->getMessage(), $exception);
         }

--- a/src/Helpers/Git.php
+++ b/src/Helpers/Git.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sammyjo20\Lasso\Helpers;
+
+use Sammyjo20\Lasso\Exceptions\GitHashException;
+
+class Git
+{
+    /**
+     * @return string|null
+     * @throws GitHashException
+     */
+    public static function getCommitHash():? string
+    {
+        try {
+            $hash = file_get_contents(
+                sprintf(base_path() . '/.git/refs/heads/%s', config('lasso.git_branch'))
+            );
+        } catch (\Exception $exception) {
+            throw new GitHashException($exception->getMessage(), $exception);
+        }
+
+        if ($hash) {
+            return substr($hash, 0, 12);
+        }
+
+        return null;
+    }
+}

--- a/src/Tasks/Publish/PublishJob.php
+++ b/src/Tasks/Publish/PublishJob.php
@@ -157,8 +157,8 @@ final class PublishJob extends BaseJob
     private function generateBundleId(): self
     {
         $id = Str::random(20);
-        if ($this->useCommit) {
 
+        if ($this->useCommit) {
             $id = Git::getCommitHash();
         }
 

--- a/src/Tasks/Publish/PublishJob.php
+++ b/src/Tasks/Publish/PublishJob.php
@@ -4,6 +4,7 @@ namespace Sammyjo20\Lasso\Tasks\Publish;
 
 use Illuminate\Support\Str;
 use Sammyjo20\Lasso\Helpers\Bundle;
+use Sammyjo20\Lasso\Helpers\Git;
 use Sammyjo20\Lasso\Tasks\BaseJob;
 use Sammyjo20\Lasso\Tasks\Command;
 use Sammyjo20\Lasso\Tasks\Webhook;
@@ -21,14 +22,18 @@ final class PublishJob extends BaseJob
     protected $usesGit = true;
 
     /**
+     * @var bool
+     */
+    protected $useCommit = false;
+
+    /**
      * PublishJob constructor.
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->generateBundleId()
-            ->deleteLassoDirectory();
+        $this->deleteLassoDirectory();
     }
 
     /**
@@ -37,6 +42,8 @@ final class PublishJob extends BaseJob
     public function run(): void
     {
         try {
+            $this->generateBundleId();
+
             $this->artisan->note('⏳ Compiling assets...');
 
             // Start with the compiler. This will run the "script" which
@@ -149,7 +156,13 @@ final class PublishJob extends BaseJob
      */
     private function generateBundleId(): self
     {
-        $this->bundleId = Str::random(20);
+        $id = Str::random(20);
+        if ($this->useCommit) {
+
+            $id = Git::getCommitHash();
+        }
+
+        $this->bundleId = $id;
 
         return $this;
     }
@@ -170,6 +183,16 @@ final class PublishJob extends BaseJob
     public function dontUseGit(): self
     {
         $this->usesGit = false;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useCommit(): self
+    {
+        $this->useCommit = true;
 
         return $this;
     }

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -215,7 +215,6 @@ final class PullJob extends BaseJob
         // If the integrity is incorrect, it could have been downloaded
         // incorrectly or tampered with!
 
-
         if (! BundleIntegrityHelper::verifyChecksum($localBundlePath, $checksum)) {
 
             if ($this->useCommit) {

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -2,7 +2,6 @@
 
 namespace Sammyjo20\Lasso\Tasks\Pull;
 
-use Sammyjo20\Lasso\Exceptions\GitHashException;
 use Sammyjo20\Lasso\Exceptions\PullJobFailed;
 use Sammyjo20\Lasso\Helpers\BundleIntegrityHelper;
 use Sammyjo20\Lasso\Helpers\FileLister;
@@ -293,11 +292,7 @@ final class PullJob extends BaseJob
     private function getBundlePath(string $file): string
     {
         if ($this->useCommit) {
-            try {
-                $file = Git::getCommitHash() . '.zip';
-            } catch (GitHashException $exception) {
-                //
-            }
+            $file = Git::getCommitHash() . '.zip';
         }
 
         return  $this->cloud->getUploadPath($file);

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -2,9 +2,11 @@
 
 namespace Sammyjo20\Lasso\Tasks\Pull;
 
+use Sammyjo20\Lasso\Exceptions\GitHashException;
 use Sammyjo20\Lasso\Exceptions\PullJobFailed;
 use Sammyjo20\Lasso\Helpers\BundleIntegrityHelper;
 use Sammyjo20\Lasso\Helpers\FileLister;
+use Sammyjo20\Lasso\Helpers\Git;
 use Sammyjo20\Lasso\Services\ArchiveService;
 use Sammyjo20\Lasso\Services\BackupService;
 use Sammyjo20\Lasso\Services\VersioningService;
@@ -17,6 +19,11 @@ final class PullJob extends BaseJob
      * @var BackupService
      */
     protected $backup;
+
+    /**
+     * @var bool
+     */
+    protected $useCommit = false;
 
     /**
      * PullJob constructor.
@@ -141,7 +148,7 @@ final class PullJob extends BaseJob
 
         // If there isn't a "lasso-bundle.json" file in the root directory,
         // that's okay - this means that the commit is in "non-git" mode. So
-        // let's just grab that file.If we don't have a file on the server
+        // let's just grab that file. If we don't have a file on the server
         // however; we need to throw an exception.
 
         if (! $this->cloud->exists($cloudPath)) {
@@ -178,11 +185,11 @@ final class PullJob extends BaseJob
      * @param string $file
      * @param string $checksum
      * @return string
-     * @throws PullJobFailed
+     * @throws PullJobFailed|\Exception
      */
     private function downloadBundleZip(string $file, string $checksum): string
     {
-        $bundlePath = $this->cloud->getUploadPath($file);
+        $bundlePath = $this->getBundlePath($file);
         $localBundlePath = base_path('.lasso/bundle.zip');
 
         if (! $this->cloud->exists($bundlePath)) {
@@ -209,7 +216,16 @@ final class PullJob extends BaseJob
         // If the integrity is incorrect, it could have been downloaded
         // incorrectly or tampered with!
 
+
         if (! BundleIntegrityHelper::verifyChecksum($localBundlePath, $checksum)) {
+
+            if ($this->useCommit) {
+
+                $this->artisan->note('Could not verify checksum using commit hash for bundle id ...');
+
+                return $localBundlePath;
+            }
+
             $this->rollBack(
                 PullJobFailed::because('The bundle Zip\'s checksum is incorrect.')
             );
@@ -268,5 +284,33 @@ final class PullJob extends BaseJob
         $this->filesystem->deleteBaseLassoDirectory();
 
         $this->filesystem->ensureDirectoryExists(base_path('.lasso'));
+    }
+
+    /**
+     * @param string $file
+     * @return string
+     */
+    private function getBundlePath(string $file): string
+    {
+        if ($this->useCommit) {
+            try {
+                $file = Git::getCommitHash() . '.zip';
+            } catch (GitHashException $exception) {
+                //
+            }
+        }
+
+        return  $this->cloud->getUploadPath($file);
+
+    }
+
+    /**
+     * @return $this
+     */
+    public function useCommit(): self
+    {
+        $this->useCommit = true;
+
+        return $this;
     }
 }

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -222,7 +222,7 @@ final class PullJob extends BaseJob
 
         if (! BundleIntegrityHelper::verifyChecksum($localBundlePath, $checksum)) {
 
-            if ($this->useCommit) {
+            if ($this->useCommit || $this->commitHash) {
 
                 $this->artisan->note('Could not verify checksum using commit hash for bundle id ...');
 

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -25,6 +25,11 @@ final class PullJob extends BaseJob
     protected $useCommit = false;
 
     /**
+     * @var string?
+     */
+    protected $commitHash = null;
+
+    /**
      * PullJob constructor.
      */
     public function __construct()
@@ -290,11 +295,15 @@ final class PullJob extends BaseJob
      */
     private function getBundlePath(string $file): string
     {
-        if ($this->useCommit) {
-            $file = Git::getCommitHash() . '.zip';
+        if ($this->commitHash) {
+            return $this->cloud->getUploadPath($this->commitHash . '.zip');
         }
 
-        return  $this->cloud->getUploadPath($file);
+        if ($this->useCommit) {
+           return $this->cloud->getUploadPath(Git::getCommitHash() . '.zip');
+        }
+
+        return $this->cloud->getUploadPath($file);
 
     }
 
@@ -304,6 +313,16 @@ final class PullJob extends BaseJob
     public function useCommit(): self
     {
         $this->useCommit = true;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function withCommit(string $commitHash): self
+    {
+        $this->commitHash = $commitHash;
 
         return $this;
     }


### PR DESCRIPTION
This commit does not change any of the existing functionality.

Both commands for publishing and pulling bundles now has an extra flag --use-commit:

If the flag is passed, the command will attempt to retrieve the commit hash from the git branch and use that as the bundle ID. When pulling with the flag, the bundle ID from the lasso-bundle.json file will be ignored, and the git commit will be used for the zip file name.

This is useful in the scenario where the user wants the bundles to coincide with the git hashes, adding the following 2 advantages:

The bundles can be generated during the CI pipeline, without having commit or upload the bundle file to the filesystem.
Rolling back to previous commits ensures that the corresponding bundle is available and easily identifiable.