### PR TITLE
Added code to allow specifying a prefix when storing the bundles on the cloud

### DIFF
--- a/config/lasso.php
+++ b/config/lasso.php
@@ -53,6 +53,13 @@ return [
         'environment' => env('LASSO_ENV', null),
 
         /*
+         * Lasso can add a prefix to the bundle file, in order to store
+         * multiple bundle files in the same filesystem for different
+         * environments
+         */
+        'prefix' => env('LASSO_PREFIX', ''),
+
+        /*
          * Lasso will automatically version the assets. This is useful if you
          * suddenly need to roll back a deployment and use an older version
          * of built files. You can set the maximum amount of files stored here.

--- a/src/Tasks/Publish/PublishJob.php
+++ b/src/Tasks/Publish/PublishJob.php
@@ -93,7 +93,7 @@ final class PublishJob extends BaseJob
 
                 $this->filesystem->put($bundlePath, json_encode($bundle));
 
-                $this->cloud->uploadFile($bundlePath, 'lasso-bundle.json');
+                $this->cloud->uploadFile($bundlePath, config('lasso.storage.prefix') . 'lasso-bundle.json');
             }
 
             // Done! Let's run some cleanup, and dispatch all the

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -125,7 +125,7 @@ final class PullJob extends BaseJob
     private function getLatestBundleInfo(): array
     {
         $localPath = base_path('lasso-bundle.json');
-        $cloudPath = $this->cloud->getUploadPath('lasso-bundle.json');
+        $cloudPath = $this->cloud->getUploadPath(config('lasso.storage.prefix') . 'lasso-bundle.json');
 
         // Firstly, let's check if the local filesystem has a "lasso-bundle.json"
         // file in it's root directory.


### PR DESCRIPTION
This allows specifying a prefix such as 'qa-' or 'prod-' to the 'lasso-bundle.json' file stored online when using the --no-git flag for publishing, and again when pulling.