### PR TITLE
Replaced ->putStream() with ->put()

### DIFF
--- a/src/Helpers/Cloud.php
+++ b/src/Helpers/Cloud.php
@@ -64,7 +64,7 @@ class Cloud
         $stream = fopen($path, 'rb');
 
         // Use the stream to write the bundle to the Filesystem.
-        $this->cloudFilesystem->putStream($upload_path, $stream);
+        $this->cloudFilesystem->put($upload_path, $stream);
 
         // Close the Stream pointer because it's good practice.
         if (is_resource($stream)) {


### PR DESCRIPTION
This PR proposes a change to `Helpers/Cloud.php` and changes `->putStream()` to `->put()`. Looks like this method is no longer available in `illuminate/filesystem`.