### PR TITLE
Switched putStream to writeStream

### DIFF
--- a/src/Helpers/Cloud.php
+++ b/src/Helpers/Cloud.php
@@ -64,7 +64,7 @@ class Cloud
         $stream = fopen($path, 'rb');
 
         // Use the stream to write the bundle to the Filesystem.
-        $this->cloudFilesystem->putStream($upload_path, $stream);
+        $this->cloudFilesystem->writeStream($upload_path, $stream);
 
         // Close the Stream pointer because it's good practice.
         if (is_resource($stream)) {


### PR DESCRIPTION
This PR fixes Lasso for Laravel 9. 

Laravel 9 came with v3 of Flysystem which had removed the `putStream` functions and replaced it with `writeStream`.

Tested and works great with Laravel 9.