### PR TITLE
Fire Webhooks per environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "orchestra/testbench": "^7.0 || ^8.0",
         "friendsofphp/php-cs-fixer": "^3.1.0",
         "spatie/ray": "^1.33",
-        "pestphp/pest": "^1.21"
+        "pestphp/pest": "^1.21",
+        "guzzlehttp/guzzle": "^7.5"
     },
     "extra": {
         "laravel": {

--- a/src/Tasks/BaseJob.php
+++ b/src/Tasks/BaseJob.php
@@ -71,15 +71,28 @@ abstract class BaseJob implements JobInterface
     /**
      * @return array
      */
-    protected function getAlwaysRunWebhooks(array $webhooks): array
+    protected function filterWebhooksToRun(array $webhooks): array
     {
-        $numericallyIndexedWebhooks = $this->numericallyIndexedWebhooks($webhooks);
-        
-        return array_key_exists('always', $webhooks) ?
-            array_merge($webhooks['always'], $numericallyIndexedWebhooks) :
-            $numericallyIndexedWebhooks;
+        $lassoEnvironment = config('lasso.storage.environment', null);
+
+        return array_key_exists($lassoEnvironment, $webhooks) ?
+            array_merge($webhooks[$lassoEnvironment], $this->getAlwaysRunWebhooks($webhooks)) :
+            $this->getAlwaysRunWebhooks($webhooks);
     }
 
+    /**
+     * @return array
+     */
+    protected function getAlwaysRunWebhooks(array $webhooks): array
+    {        
+        return array_key_exists('always', $webhooks) ?
+            array_merge($webhooks['always'], $this->numericallyIndexedWebhooks($webhooks)) :
+            $this->numericallyIndexedWebhooks($webhooks);
+    }
+
+    /**
+     * @return array
+     */
     private function numericallyIndexedWebhooks($webhooks): array
     {
         return array_filter(array_values($webhooks), 'is_string');

--- a/src/Tasks/BaseJob.php
+++ b/src/Tasks/BaseJob.php
@@ -67,4 +67,12 @@ abstract class BaseJob implements JobInterface
 
         return $this;
     }
+
+    /**
+     * @return array
+     */
+    protected function getAlwaysRunWebhooks(array $webhooks): array
+    {
+        return array_key_exists('always', $webhooks) ? $webhooks['always'] : [];
+    }
 }

--- a/src/Tasks/BaseJob.php
+++ b/src/Tasks/BaseJob.php
@@ -73,6 +73,15 @@ abstract class BaseJob implements JobInterface
      */
     protected function getAlwaysRunWebhooks(array $webhooks): array
     {
-        return array_key_exists('always', $webhooks) ? $webhooks['always'] : [];
+        $numericallyIndexedWebhooks = $this->numericallyIndexedWebhooks($webhooks);
+        
+        return array_key_exists('always', $webhooks) ?
+            array_merge($webhooks['always'], $numericallyIndexedWebhooks) :
+            $numericallyIndexedWebhooks;
+    }
+
+    private function numericallyIndexedWebhooks($webhooks): array
+    {
+        return array_filter(array_values($webhooks), 'is_string');
     }
 }

--- a/src/Tasks/Publish/PublishJob.php
+++ b/src/Tasks/Publish/PublishJob.php
@@ -153,18 +153,10 @@ final class PublishJob extends BaseJob
         if (! count($webhooks)) {
             return;
         }
-        
-        $lassoEnvironment = config('lasso.storage.environment', null);
 
         $this->artisan->note('⏳ Dispatching webhooks...');
 
-        if (array_key_exists($lassoEnvironment, $webhooks)) {
-            foreach ($webhooks[$lassoEnvironment] as $webhook) {
-                Webhook::send($webhook, 'publish');
-            }
-        }
-
-        foreach ($this->getAlwaysRunWebhooks($webhooks) as $webhook) {
+        foreach ($this->filterWebhooksToRun($webhooks) as $webhook) {
             Webhook::send($webhook, 'publish');
         }
 

--- a/src/Tasks/Publish/PublishJob.php
+++ b/src/Tasks/Publish/PublishJob.php
@@ -158,7 +158,6 @@ final class PublishJob extends BaseJob
 
         $this->artisan->note('⏳ Dispatching webhooks...');
 
-
         if (array_key_exists($lassoEnvironment, $webhooks)) {
             foreach ($webhooks[$lassoEnvironment] as $webhook) {
                 Webhook::send($webhook, 'publish');

--- a/src/Tasks/Publish/PublishJob.php
+++ b/src/Tasks/Publish/PublishJob.php
@@ -153,10 +153,19 @@ final class PublishJob extends BaseJob
         if (! count($webhooks)) {
             return;
         }
+        
+        $lassoEnvironment = config('lasso.storage.environment', null);
 
         $this->artisan->note('⏳ Dispatching webhooks...');
 
-        foreach ($webhooks as $webhook) {
+
+        if (array_key_exists($lassoEnvironment, $webhooks)) {
+            foreach ($webhooks[$lassoEnvironment] as $webhook) {
+                Webhook::send($webhook, 'publish');
+            }
+        }
+
+        foreach ($this->getAlwaysRunWebhooks($webhooks) as $webhook) {
             Webhook::send($webhook, 'publish');
         }
 

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -119,10 +119,18 @@ final class PullJob extends BaseJob
         if (! count($webhooks)) {
             return;
         }
+        
+        $lassoEnvironment = config('lasso.storage.environment', null);
 
         $this->artisan->note('⏳ Dispatching webhooks...');
 
-        foreach ($webhooks as $webhook) {
+        if (array_key_exists($lassoEnvironment, $webhooks)) {
+            foreach ($webhooks[$lassoEnvironment] as $webhook) {
+                Webhook::send($webhook, 'pull');
+            }
+        }
+
+        foreach ($this->getAlwaysRunWebhooks($webhooks) as $webhook) {
             Webhook::send($webhook, 'pull');
         }
 

--- a/src/Tasks/Pull/PullJob.php
+++ b/src/Tasks/Pull/PullJob.php
@@ -119,18 +119,10 @@ final class PullJob extends BaseJob
         if (! count($webhooks)) {
             return;
         }
-        
-        $lassoEnvironment = config('lasso.storage.environment', null);
 
         $this->artisan->note('⏳ Dispatching webhooks...');
 
-        if (array_key_exists($lassoEnvironment, $webhooks)) {
-            foreach ($webhooks[$lassoEnvironment] as $webhook) {
-                Webhook::send($webhook, 'pull');
-            }
-        }
-
-        foreach ($this->getAlwaysRunWebhooks($webhooks) as $webhook) {
+        foreach ($this->filterWebhooksToRun($webhooks) as $webhook) {
             Webhook::send($webhook, 'pull');
         }
 

--- a/tests/Commands/WebhookDispatchTest.php
+++ b/tests/Commands/WebhookDispatchTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Sammyjo20\Lasso\Tests\Commands;
+
+use Mockery as m;
+use Sammyjo20\Lasso\Tests\TestCase;
+use Illuminate\Http\Client\Request;
+use Sammyjo20\Lasso\Container\Artisan;
+use Sammyjo20\Lasso\Tasks\Publish\PublishJob;
+use Illuminate\Support\Facades\{Http,Storage};
+
+class WebhookDispatchTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('assets');
+
+        $this->webhooks = $this->webhooks();
+
+        config(['lasso.storage.environment' => 'staging']);
+        
+        Http::fake(['example.com/*' => Http::response('', 200)]);
+    }
+
+    /** @test */
+    function it_can_dispatch_webhooks_per_environment_after_successful_publish_command(): void
+    {
+        $mock = m::mock($artisan = new Artisan);
+        $mock->shouldReceive('note')->twice()->andReturn($artisan);
+        $this->app->instance('Sammyjo20\Lasso\Container\Artisan', $mock);
+        $publishJob = new PublishJob;
+
+        $publishJob->dispatchWebhooks($this->webhooks);
+
+        Http::assertSentCount(2);
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://example.com/staging';
+        });
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://example.com/always';
+        });
+        Http::assertNotSent(function (Request $request) {
+            return $request->url() === 'http://example.com/production';
+        });
+    }
+
+    private function webhooks(): array
+    {
+        return [
+            'always'     => ['https://example.com/always'],
+            'staging'    => ['https://example.com/staging'],
+            'production' => ['https://example.com/production'],
+        ];
+    }
+
+    public function tearDown(): void
+    {
+        m::close();
+    }
+}

--- a/tests/Commands/WebhookDispatchTest.php
+++ b/tests/Commands/WebhookDispatchTest.php
@@ -45,6 +45,18 @@ class WebhookDispatchTest extends TestCase
     }
 
     /** @test */
+    function it_can_always_dispatch_webhooks_which_are_numerically_indexed_in_publish_job(): void {
+        $this->webhooks[0] = 'https://example.com';
+
+        (new PublishJob)->dispatchWebhooks($this->webhooks);
+
+        Http::assertSentCount(3);
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://example.com';
+        });
+    }
+
+    /** @test */
     function it_can_dispatch_webhooks_per_environment_after_successful_pull_command(): void
     {
         (new PullJob)->dispatchWebhooks($this->webhooks);

--- a/tests/Commands/WebhookDispatchTest.php
+++ b/tests/Commands/WebhookDispatchTest.php
@@ -73,6 +73,18 @@ class WebhookDispatchTest extends TestCase
         });
     }
 
+    /** @test */
+    function it_can_always_dispatch_webhooks_which_are_numerically_indexed_in_pull_job(): void {
+        $this->webhooks[9] = 'https://example.com';
+
+        (new PullJob)->dispatchWebhooks($this->webhooks);
+
+        Http::assertSentCount(3);
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://example.com';
+        });
+    }
+
     private function webhooks(): array
     {
         return [


### PR DESCRIPTION
 Added test suite.

added guzzle as dev dependency to run laraval http client.

Apart from the description in issue  #67 this pr also runs webhooks that are numerically indexed in lasso config for backward compatibility.