### PR TITLE
Change to double-quoted string

### DIFF
--- a/src/Helpers/Git.php
+++ b/src/Helpers/Git.php
@@ -20,7 +20,7 @@ class Git
     public static function getCommitHash(): ? string
     {
         try {
-            $branch = str_replace('\n', '', last(explode('/', (string)file_get_contents(base_path() . '/.git/HEAD'))));
+            $branch = str_replace("\n", '', last(explode('/', (string)file_get_contents(base_path() . '/.git/HEAD'))));
             $hash = file_get_contents(base_path() . '/.git/refs/heads/' . $branch);
         } catch (Exception $exception) {
             throw new GitHashException($exception->getMessage(), previous: $exception);


### PR DESCRIPTION
With single quotes ('\n'), the str_replace() function won't recognize it as a newline character. It will look for the literal sequence of a backslash followed by n, which I don't think we want.